### PR TITLE
Move (de)serialization out and operate on MessageB2G and MessageG2B structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,25 +18,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -51,16 +36,9 @@ dependencies = [
 name = "blimp_onboard_software"
 version = "0.1.0"
 dependencies = [
- "postcard",
  "serde",
  "tokio",
 ]
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
@@ -69,73 +47,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cobs"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version",
- "serde",
- "spin",
- "stable_deref_trait",
-]
-
-[[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
-
-[[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "memchr"
@@ -145,9 +66,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -168,23 +89,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
-name = "postcard"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "heapless",
- "serde",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -203,27 +111,6 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -246,25 +133,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -273,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "pin-project-lite",
@@ -357,4 +229,8 @@ version = "0.1.0"
 
 [[patch.unused]]
 name = "blimp_ground_ws_interface"
+version = "0.2.0"
+
+[[patch.unused]]
+name = "physsim"
 version = "0.1.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,9 +228,9 @@ name = "blimp_comm"
 version = "0.1.0"
 
 [[patch.unused]]
-name = "blimp_ground_ws_interface"
-version = "0.2.0"
-
-[[patch.unused]]
 name = "physsim"
 version = "0.1.0"
+
+[[patch.unused]]
+name = "blimp_ground_ws_interface"
+version = "0.2.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "blimp_onboard_software"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "tokio",
@@ -224,13 +224,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[patch.unused]]
-name = "blimp_comm"
-version = "0.1.0"
+name = "blimp_ground_ws_interface"
+version = "0.2.0"
 
 [[patch.unused]]
 name = "physsim"
 version = "0.1.0"
 
 [[patch.unused]]
-name = "blimp_ground_ws_interface"
+name = "blimp_comm"
 version = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blimp_onboard_software"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-postcard = { version = "1.0.10", features = ["use-std"] }
-serde = "1.0.215"
+serde = { version = "1.0.215", features = ["default", "derive"] }
 tokio = { version = "1.44.1", features = ["default", "sync"] }

--- a/src/obsw_algo.rs
+++ b/src/obsw_algo.rs
@@ -105,53 +105,19 @@ impl BlimpAlgorithm<BlimpEvent, BlimpAction> for BlimpMainAlgo {
                     let prev_lat = self.gps_location.read().await.unwrap_or((0.0, 0.0)).0;
                     *self.gps_location.write().await = Some((prev_lat, *longitude));
                 }
-                BlimpEvent::GetMsg(msg) => {
-                    match msg {
-                        MessageG2B::Ping(id) => {
-                            // if let Some(fut) =
-                            //     self.action_callback.read().await.as_ref().map(|x| async {
-                            //         self.perform_action(
-                            //             x.as_ref(),
-                            //             BlimpAction::SendMsg(
-                            //                 postcard::to_stdvec::<MessageB2G>(
-                            //                     &MessageB2G::Pong(id),
-                            //                 )
-                            //                 .unwrap(),
-                            //             ),
-                            //         )
-                            //         .await
-                            //     })
-                            // {
-                            //     fut.await;
-                            // }
-                            self.perform_action(BlimpAction::SendMsg(Box::new(MessageB2G::Pong(
-                                *id,
-                            ))))
+                BlimpEvent::GetMsg(msg) => match msg {
+                    MessageG2B::Ping(id) => {
+                        self.perform_action(BlimpAction::SendMsg(Box::new(MessageB2G::Pong(*id))))
                             .await;
-                        }
-                        MessageG2B::Pong(_id) => {}
-                        MessageG2B::Control(ctrl) => {
-                            self.handle_event(BlimpEvent::Control(ctrl.clone())).await;
-                        }
                     }
-                }
+                    MessageG2B::Pong(_id) => {}
+                    MessageG2B::Control(ctrl) => {
+                        self.handle_event(BlimpEvent::Control(ctrl.clone())).await;
+                    }
+                },
                 _ => {}
             }
             if matches!(&ev, BlimpEvent::SensorDataF64(..)) {
-                // if let Some(fut) = self.action_callback.read().await.as_ref().map(|x| async {
-                //     self.perform_action(
-                //         x,
-                //         BlimpAction::SendMsg(
-                //             postcard::to_stdvec::<MessageB2G>(&MessageB2G::ForwardEvent(
-                //                 ev.clone(),
-                //             ))
-                //             .unwrap(),
-                //         ),
-                //     )
-                //     .await
-                // }) {
-                //     fut.await;
-                // }
                 self.perform_action(BlimpAction::SendMsg(Box::new(MessageB2G::ForwardEvent(
                     ev.clone(),
                 ))))
@@ -191,42 +157,6 @@ impl BlimpMainAlgo {
         let curr_flight_mode = self.curr_flight_mode.read().await;
         match *curr_flight_mode {
             FlightMode::Manual => {
-                // if let Some(fut) = self.action_callback.read().await.as_ref().map(|x| {
-                //     async {
-                //         for i in 0..4 {
-                //             let controls = self.controls.read().await;
-                //             let speed: i32 = controls.throttle
-                //                 + (if i % 2 == 0 { 1 } else { -1 }) * controls.yaw
-                //                 + controls.elevation;
-                //             //Motor
-                //             self.perform_action(
-                //                 x.as_ref(),
-                //                 BlimpAction::SetMotor { motor: i, speed },
-                //             )
-                //             .await;
-                //             // Up-down servo
-                //             self.perform_action(
-                //                 x.as_ref(),
-                //                 BlimpAction::SetServo {
-                //                     servo: 2 * i,
-                //                     location: controls.elevation as i16,
-                //                 },
-                //             )
-                //             .await;
-                //             //Sideways servo
-                //             self.perform_action(
-                //                 x.as_ref(),
-                //                 BlimpAction::SetServo {
-                //                     servo: 2 * i + 1,
-                //                     location: controls.yaw as i16,
-                //                 },
-                //             )
-                //             .await;
-                //         }
-                //     }
-                // }) {
-                //     fut.await;
-                // }
                 for i in 0..4 {
                     let controls = self.controls.read().await;
                     let speed: i32 = controls.throttle
@@ -264,10 +194,6 @@ impl BlimpMainAlgo {
             action,
             BlimpAction::SetMotor { .. } | BlimpAction::SetServo { .. }
         ) {
-            // action_callback.read().await(BlimpAction::SendMsg(
-            //     postcard::to_stdvec::<MessageB2G>(&MessageB2G::ForwardAction(action)).unwrap(),
-            // ))
-            // .await;
             if let Some(ac) = &*self.action_callback.read().await {
                 ac(BlimpAction::SendMsg(Box::new(MessageB2G::ForwardAction(
                     action,

--- a/src/obsw_algo.rs
+++ b/src/obsw_algo.rs
@@ -2,7 +2,6 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use postcard;
 use serde;
 use tokio::sync::RwLock as TRwLock;
 
@@ -19,7 +18,8 @@ pub struct Controls {
 pub enum BlimpAction {
     SetServo { servo: u8, location: i16 },
     SetMotor { motor: u8, speed: i32 },
-    SendMsg(Vec<u8>),
+    SendMsg(Box<MessageB2G>), // This has to be boxed, because otherwise we would have infinitely
+                              // sized struct
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
@@ -33,7 +33,7 @@ pub enum SensorType {
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub enum BlimpEvent {
     Control(Controls),
-    GetMsg(Vec<u8>),
+    GetMsg(MessageG2B),
     SensorDataF64(SensorType, f64),
 }
 
@@ -106,38 +106,33 @@ impl BlimpAlgorithm<BlimpEvent, BlimpAction> for BlimpMainAlgo {
                     *self.gps_location.write().await = Some((prev_lat, *longitude));
                 }
                 BlimpEvent::GetMsg(msg) => {
-                    if let Ok(msg_deserialized) = postcard::from_bytes::<MessageG2B>(&msg) {
-                        match msg_deserialized {
-                            MessageG2B::Ping(id) => {
-                                // if let Some(fut) =
-                                //     self.action_callback.read().await.as_ref().map(|x| async {
-                                //         self.perform_action(
-                                //             x.as_ref(),
-                                //             BlimpAction::SendMsg(
-                                //                 postcard::to_stdvec::<MessageB2G>(
-                                //                     &MessageB2G::Pong(id),
-                                //                 )
-                                //                 .unwrap(),
-                                //             ),
-                                //         )
-                                //         .await
-                                //     })
-                                // {
-                                //     fut.await;
-                                // }
-                                self.perform_action(BlimpAction::SendMsg(
-                                    postcard::to_stdvec::<MessageB2G>(&MessageB2G::Pong(id))
-                                        .unwrap(),
-                                ))
-                                .await;
-                            }
-                            MessageG2B::Pong(_id) => {}
-                            MessageG2B::Control(ctrl) => {
-                                self.handle_event(BlimpEvent::Control(ctrl)).await;
-                            }
+                    match msg {
+                        MessageG2B::Ping(id) => {
+                            // if let Some(fut) =
+                            //     self.action_callback.read().await.as_ref().map(|x| async {
+                            //         self.perform_action(
+                            //             x.as_ref(),
+                            //             BlimpAction::SendMsg(
+                            //                 postcard::to_stdvec::<MessageB2G>(
+                            //                     &MessageB2G::Pong(id),
+                            //                 )
+                            //                 .unwrap(),
+                            //             ),
+                            //         )
+                            //         .await
+                            //     })
+                            // {
+                            //     fut.await;
+                            // }
+                            self.perform_action(BlimpAction::SendMsg(Box::new(MessageB2G::Pong(
+                                *id,
+                            ))))
+                            .await;
                         }
-                    } else {
-                        eprintln!("Error occurred while deseerializing message");
+                        MessageG2B::Pong(_id) => {}
+                        MessageG2B::Control(ctrl) => {
+                            self.handle_event(BlimpEvent::Control(ctrl.clone())).await;
+                        }
                     }
                 }
                 _ => {}
@@ -157,10 +152,9 @@ impl BlimpAlgorithm<BlimpEvent, BlimpAction> for BlimpMainAlgo {
                 // }) {
                 //     fut.await;
                 // }
-                self.perform_action(BlimpAction::SendMsg(
-                    postcard::to_stdvec::<MessageB2G>(&MessageB2G::ForwardEvent(ev.clone()))
-                        .unwrap(),
-                ))
+                self.perform_action(BlimpAction::SendMsg(Box::new(MessageB2G::ForwardEvent(
+                    ev.clone(),
+                ))))
                 .await;
             }
         })
@@ -275,9 +269,9 @@ impl BlimpMainAlgo {
             // ))
             // .await;
             if let Some(ac) = &*self.action_callback.read().await {
-                ac(BlimpAction::SendMsg(
-                    postcard::to_stdvec::<MessageB2G>(&MessageB2G::ForwardAction(action)).unwrap(),
-                ))
+                ac(BlimpAction::SendMsg(Box::new(MessageB2G::ForwardAction(
+                    action,
+                ))))
                 .await;
             }
         }

--- a/src/obsw_interface.rs
+++ b/src/obsw_interface.rs
@@ -1,7 +1,6 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use tokio::sync::RwLock as TRwLock;
 
 pub trait BlimpAlgorithm<EventType, ActionType> {
     fn handle_event(&self, ev: EventType) -> Pin<Box<impl Future<Output = ()>>>;


### PR DESCRIPTION
Serialization and deserialization will be done in `blimp_onboard_d`.
In case of simulator, serializations will be able to be avoided now.